### PR TITLE
Replace reCAPTCHA with honeypot spam protection

### DIFF
--- a/app/formulario/page.tsx
+++ b/app/formulario/page.tsx
@@ -457,18 +457,17 @@ export default function FormularioPage() {
               ]}
             />
 
-            {/* reCAPTCHA */}
-            <div className="mt-8 pt-6 border-t border-gray-200">
-              <p className="text-sm font-semibold text-primary mb-4">
-                Verificación de seguridad
-              </p>
-              <ReCAPTCHA
-                sitekey={
-                  process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY ||
-                  "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"
-                }
-                onChange={setRecaptchaToken}
-                onExpired={() => setRecaptchaToken(null)}
+            {/* Honeypot field for spam protection - hidden from users */}
+            <div style={{ display: "none" }}>
+              <label htmlFor="website">Website (leave blank):</label>
+              <input
+                id="website"
+                name="website"
+                type="text"
+                value={honeypot}
+                onChange={(e) => setHoneypot(e.target.value)}
+                autoComplete="off"
+                tabIndex={-1}
               />
             </div>
           </FormStep>

--- a/app/formulario/page.tsx
+++ b/app/formulario/page.tsx
@@ -32,7 +32,7 @@ export default function FormularioPage() {
     resetForm,
   } = useMultiStepForm();
 
-  const [recaptchaToken, setRecaptchaToken] = useState<string | null>(null);
+  const [honeypot, setHoneypot] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
 

--- a/app/formulario/page.tsx
+++ b/app/formulario/page.tsx
@@ -514,7 +514,7 @@ export default function FormularioPage() {
                 onClick={() => {
                   setIsSubmitted(false);
                   resetForm();
-                  setRecaptchaToken(null);
+                  setHoneypot("");
                 }}
                 className="btn-secondary"
               >

--- a/app/formulario/page.tsx
+++ b/app/formulario/page.tsx
@@ -588,10 +588,7 @@ export default function FormularioPage() {
             onNext={handleNext}
             onSubmit={handleSubmit}
             isSubmitting={isSubmitting}
-            canProceed={
-              currentStep < totalSteps - 1 ||
-              (currentStep === totalSteps - 1 && recaptchaToken !== null)
-            }
+            canProceed={true}
           />
         </div>
       </main>

--- a/app/formulario/page.tsx
+++ b/app/formulario/page.tsx
@@ -43,8 +43,10 @@ export default function FormularioPage() {
   };
 
   const handleSubmit = async () => {
-    if (!recaptchaToken) {
-      alert("Por favor completa el reCAPTCHA");
+    // Honeypot spam protection - if filled, it's likely a bot
+    if (honeypot.trim() !== "") {
+      console.log("Honeypot triggered - potential spam submission blocked");
+      alert("Error al enviar el formulario. Por favor intenta de nuevo.");
       return;
     }
 
@@ -60,7 +62,6 @@ export default function FormularioPage() {
 
       // Here you would typically send the data to your backend
       console.log("Form data:", formData);
-      console.log("reCAPTCHA token:", recaptchaToken);
 
       setIsSubmitted(true);
     } catch (error) {

--- a/app/formulario/page.tsx
+++ b/app/formulario/page.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState } from "react";
 import Link from "next/link";
-import ReCAPTCHA from "react-google-recaptcha";
 import { useMultiStepForm } from "../../hooks/useMultiStepForm";
 import { FormField, FormStep } from "../../components/FormField";
 import { ProgressIndicator } from "../../components/ProgressIndicator";


### PR DESCRIPTION
Replace Google reCAPTCHA implementation with a honeypot field for spam protection.

Changes made:
- Remove react-google-recaptcha import and dependency
- Replace recaptchaToken state with honeypot state
- Add hidden honeypot input field (website field) that should remain empty
- Update spam detection logic to check if honeypot field is filled
- Remove reCAPTCHA component and security verification section
- Update form reset logic to clear honeypot instead of recaptcha token
- Simplify canProceed logic by removing reCAPTCHA validation requirement
- Remove reCAPTCHA token from console logging

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/4ff8a7cb440b44acb6a1b967644f5a3c/pixel-garden)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4ff8a7cb440b44acb6a1b967644f5a3c</projectId>-->
<!--<branchName>pixel-garden</branchName>-->